### PR TITLE
Add support for TypeScript files 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-**Nothing yet**
+### Added
+
+- Add support for TypeScript files in `jsConsoleCommands`, `jsLocalEslintChange` and `jsTestShortcuts`.
 
 ## [1.3.1] - 2018-11-13
 

--- a/src/rules/js/consoleCommands.js
+++ b/src/rules/js/consoleCommands.js
@@ -10,7 +10,7 @@ export default async ({ logType } = {}) => {
     fileAddedLineMatch(filename, /console\.[a-z]+/);
 
   const log = getMessageLogger(logType);
-  const jsFiles = committedFilesGrep(/(\.js|\.jsx)$/i);
+  const jsFiles = committedFilesGrep(/\.(js|jsx|ts)$/i);
   await jsFiles.forEach(async filename => {
     const hasConsole = await hasJsConsoleCommands(filename);
     if (hasConsole) {

--- a/src/rules/js/consoleCommands.test.js
+++ b/src/rules/js/consoleCommands.test.js
@@ -8,11 +8,13 @@ const validJs = 'valid.js';
 const invalidJs = 'invalid.js';
 const invalidJsCase = 'invalid.Js';
 const invalidJsx = 'invalid.jsx';
+const invalidTs = 'invalid.ts';
 const mockFiles = {
   [validJs]: 'const foo = 42;',
   [invalidJs]: 'console.log("foo");',
   [invalidJsCase]: 'console.log("foo");',
   [invalidJsx]: 'console.log("foo");',
+  [invalidTs]: 'console.log("foo");',
 };
 
 helpers.setMockFilesContent(mockFiles);
@@ -34,11 +36,33 @@ describe('jsConsoleCommands', () => {
     expect(global.warn).not.toHaveBeenCalled();
   });
 
-  it('should warn when any console command is used', async () => {
+  it('should warn when any console command is used (js)', async () => {
     const files = [validJs, invalidJs];
     helpers.setMockCommittedFiles(files);
 
     const expectedMsg = buildMessage(invalidJs);
+
+    await jsConsoleCommands();
+
+    expect(global.warn).toHaveBeenCalledWith(expectedMsg);
+  });
+
+  it('should warn when any console command is used (jsx)', async () => {
+    const files = [validJs, invalidJsx];
+    helpers.setMockCommittedFiles(files);
+
+    const expectedMsg = buildMessage(invalidJsx);
+
+    await jsConsoleCommands();
+
+    expect(global.warn).toHaveBeenCalledWith(expectedMsg);
+  });
+
+  it('should warn when any console command is used (ts)', async () => {
+    const files = [validJs, invalidTs];
+    helpers.setMockCommittedFiles(files);
+
+    const expectedMsg = buildMessage(invalidTs);
 
     await jsConsoleCommands();
 

--- a/src/rules/js/localEslintChange.js
+++ b/src/rules/js/localEslintChange.js
@@ -10,7 +10,7 @@ export default async ({ logType } = {}) => {
     fileAddedLineMatch(filename, /eslint-disable/);
 
   const log = getMessageLogger(logType);
-  const jsFiles = committedFilesGrep(/(\.js|\.jsx)$/i);
+  const jsFiles = committedFilesGrep(/\.(js|jsx|ts)$/i);
   await jsFiles.forEach(async filename => {
     const hasDisabledRules = await hasDisabledEslint(filename);
     if (hasDisabledRules) {

--- a/src/rules/js/localEslintChange.test.js
+++ b/src/rules/js/localEslintChange.test.js
@@ -5,11 +5,13 @@ const validJs = 'valid.js';
 const invalidJs = 'invalid.js';
 const invalidJsCase = 'invalid.Js';
 const invalidJsx = 'invalid.jsx';
+const invalidTs = 'invalid.ts';
 const mockFiles = {
   [validJs]: 'const foo = 42;',
   [invalidJs]: 'eslint-disable-line foo',
   [invalidJsCase]: 'eslint-disable foo',
   [invalidJsx]: 'eslint-disable-next-line foo',
+  [invalidTs]: 'eslint-disable-line foo',
 };
 
 helpers.setMockFilesContent(mockFiles);
@@ -50,6 +52,17 @@ describe('jsLocalEslintChange', () => {
 
     expect(global.warn).toHaveBeenCalledWith(
       expect.stringContaining(invalidJsx),
+    );
+  });
+
+  it('should warn when some eslint rule has been disabled (ts)', async () => {
+    const files = [validJs, invalidTs];
+    helpers.setMockCommittedFiles(files);
+
+    await jsLocalEslintChange();
+
+    expect(global.warn).toHaveBeenCalledWith(
+      expect.stringContaining(invalidTs),
     );
   });
 

--- a/src/rules/js/testShortcuts.js
+++ b/src/rules/js/testShortcuts.js
@@ -20,7 +20,7 @@ export default async ({ logTypeSkipped, logTypeFocused } = {}) => {
 
   const logSkipped = getMessageLogger(logTypeSkipped);
   const logFocused = getMessageLogger(logTypeFocused);
-  const jsFiles = committedFilesGrep(/(\.test\.js|\.test\.jsx|\.spec\.js)$/i);
+  const jsFiles = committedFilesGrep(/\.(test|spec)\.(js|jsx|ts)$/i);
   await jsFiles.forEach(async filename => {
     const [hasSkippedTests, hasFocusedTests] = await Promise.all([
       hasJsSkippedTests(filename),

--- a/src/rules/js/testShortcuts.test.js
+++ b/src/rules/js/testShortcuts.test.js
@@ -19,6 +19,7 @@ const fit = 'fit.test.js';
 const itOnly = 'itOnly.test.js';
 const testOnly = 'testOnly.test.js';
 const invalidJsx = 'xdescribe.test.jsx';
+const invalidTs = 'xdescribe.test.ts';
 const invalidSpec = 'xdescribe.spec.jsx';
 const invalidCase = 'xdescribe.test.JS';
 const mockFiles = {
@@ -34,6 +35,7 @@ const mockFiles = {
   [itOnly]: 'it.only("should ...")',
   [testOnly]: 'test.only("should ...")',
   [invalidJsx]: 'xdescribe("should ...")',
+  [invalidTs]: 'xdescribe("should ...")',
   [invalidSpec]: 'xdescribe("should ...")',
   [invalidCase]: 'xdescribe("should ...")',
 };
@@ -170,6 +172,28 @@ describe('jsTestShortcuts', () => {
 
       expect(global.warn).toHaveBeenCalledWith(expectedMsg);
     });
+  });
+
+  it('should support jsx files', async () => {
+    const files = [validJs, invalidJsx];
+    helpers.setMockCommittedFiles(files);
+
+    const expectedMsg = buildMessageSkipped(invalidJsx);
+
+    await jsTestShortcuts();
+
+    expect(global.warn).toHaveBeenCalledWith(expectedMsg);
+  });
+
+  it('should support ts files', async () => {
+    const files = [validJs, invalidTs];
+    helpers.setMockCommittedFiles(files);
+
+    const expectedMsg = buildMessageSkipped(invalidTs);
+
+    await jsTestShortcuts();
+
+    expect(global.warn).toHaveBeenCalledWith(expectedMsg);
   });
 
   it('should ignore file extension casing', async () => {


### PR DESCRIPTION
Add support for TypeScript files in `jsConsoleCommands`, `jsLocalEslintChange` and `jsTestShortcuts`.