### PR TITLE
Fix the regular expressions exported in "commonCommitMessage"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-**Nothing yet**
+- Fix the regular expressions exported in [`commonCommitMessage`](docs/validations.md#commoncommitmessage).
 
 ## [1.19.0] - 2020-3-6
 

--- a/src/rules/common/__tests__/commitMessage.test.js
+++ b/src/rules/common/__tests__/commitMessage.test.js
@@ -221,7 +221,7 @@ describe('commonCommitMessage', () => {
         });
 
         it(`should not match when the ticket is not at the start of the string - ${type}`, () => {
-          const message = 'Some text [FOO-123]';
+          const message = 'Some text FOO-123 more';
 
           const result = message.match(regex);
 
@@ -314,7 +314,7 @@ describe('commonCommitMessage', () => {
         });
 
         it(`should not match when the ticket is not at the start of the string - ${type}`, () => {
-          const message = 'Some text [FOO-123]';
+          const message = 'Some text FOO-123 more';
 
           const result = message.match(regex);
 

--- a/src/rules/common/commitMessage.js
+++ b/src/rules/common/commitMessage.js
@@ -5,10 +5,10 @@
 import getMessageLogger from '../getMessageLogger';
 import { commits } from '../helpers';
 
-export const COMMON_COMMIT_MESSAGE_JIRA_REGEX = /^(\[[a-z]+-\d+\] )|([a-z]+-\d+:? )|(\[NO-JIRA\] )|(NO-JIRA:? )/i;
-export const COMMON_COMMIT_MESSAGE_JIRA_OR_MERGE_REGEX = /^(\[[a-z]+-\d+\] )|([a-z]+-\d+:? )|(\[NO-JIRA\] )|(NO-JIRA:? )|(Merge branch )|(Merge pull request )/i;
-export const COMMON_COMMIT_MESSAGE_NO_JIRA_REGEX = /^(\[NO-JIRA\] )|(NO-JIRA:? )/i;
-export const COMMON_COMMIT_MESSAGE_NO_JIRA_OR_MERGE_REGEX = /^(\[NO-JIRA\] )|(NO-JIRA:? )|(Merge branch )|(Merge pull request )/i;
+export const COMMON_COMMIT_MESSAGE_JIRA_REGEX = /^((\[[a-z]+-\d+\])|([a-z]+-\d+:?)|(\[NO-JIRA\])|(NO-JIRA:?)) /i;
+export const COMMON_COMMIT_MESSAGE_JIRA_OR_MERGE_REGEX = /^((\[[a-z]+-\d+\])|([a-z]+-\d+:?)|(\[NO-JIRA\])|(NO-JIRA:?)|(Merge branch)|(Merge pull request)) /i;
+export const COMMON_COMMIT_MESSAGE_NO_JIRA_REGEX = /^((\[NO-JIRA\])|(NO-JIRA:?)) /i;
+export const COMMON_COMMIT_MESSAGE_NO_JIRA_OR_MERGE_REGEX = /^((\[NO-JIRA\])|(NO-JIRA:?)|(Merge branch)|(Merge pull request)) /i;
 export const COMMON_COMMIT_MESSAGE_JIRA_MSG =
   'Please include a JIRA ticket (like `XXX-DDDD` or `NO-JIRA` if there is no ticket) at the beginning of each commit.';
 


### PR DESCRIPTION
Regex only check that the pattern is at beginning for the first case.