### PR TITLE
Fix non-interactive release

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -35,7 +35,7 @@ async function release() {
     const releaseOptions = {
       increment: isPreRelease ? 'prerelease' : versionNumber,
       preReleaseId: preReleaseTag,
-      'non-interactive': true,
+      ci: true,
       hooks: {
         'after:bump': buildCommand,
       },


### PR DESCRIPTION
`non-interactive` has been removed in `relase-it`, and `ci` must be used instead: https://github.com/release-it/release-it/blob/master/CHANGELOG.md#v13