### PR TITLE
Split "pr" and "push" GH Actions workflows so Danger does not fail

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,8 +1,6 @@
-name: danger-plugin-toolbox CI
+name: danger-plugin-toolbox CI (PR)
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,40 @@
+name: danger-plugin-toolbox CI (Push)
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.14.2, 12.13]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install deps
+        run: npm ci --quiet
+
+      - name: Run linters
+        run: npm run lint
+
+      - name: Run tests
+        run: npm run test:coverage
+
+      - name: Run Spellcheck
+        run: npm run spellcheck:ci
+
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/scripts/update-changelog.js
+++ b/scripts/update-changelog.js
@@ -19,7 +19,7 @@ const updateChangelog = (version) => {
 };
 
 const updatePluginVersionCI = (version) => {
-  const ciScriptPath = '.github/workflows/ci.yml';
+  const ciScriptPath = '.github/workflows/pull_request.yml';
   const ciScriptData = fs.readFileSync(ciScriptPath, 'utf8');
 
   const regexp = /(danger-plugin-toolbox@)\d+\.\d+\.\d+/;


### PR DESCRIPTION
Danger step is failing when it runs in a push (looks like it's not able to detect it, same way it was doing it in Travis for example).
There's an issue created for Danger JS to implement this detection: https://github.com/danger/danger-js/issues/1066

This is the Travis log for a push:
![image](https://user-images.githubusercontent.com/7152781/98044953-0668f900-1e28-11eb-9678-381e58165ca8.png)

For now, I'm splitting the workflow in two, one for `pull_request` and one for `push` events. `push.yml` is a copy of `pull_request.yml` without the Danger step.