### PR TITLE
Change Prettier integration with eslint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
         run: (set -o pipefail; npm run lint |& tee lint.log);
         if: matrix['node-version'] == '22'
 
+      - name: Check formatting
+        run: npm run format:check
+        if: matrix['node-version'] == '22'
+
       - name: Run tests
         run: (set -o pipefail; npm run test:coverage |& tee test.log);
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,8 @@
 import js from '@eslint/js';
 import eslintComments from '@eslint-community/eslint-plugin-eslint-comments';
+import eslintConfigPrettier from 'eslint-config-prettier';
 import importPlugin from 'eslint-plugin-import-x';
 import jestPlugin from 'eslint-plugin-jest';
-import prettier from 'eslint-plugin-prettier';
 import globals from 'globals';
 
 export default [
@@ -358,13 +358,6 @@ export default [
     },
   },
 
-  // eslint-plugin-prettier
-  {
-    plugins: { prettier },
-    rules: {
-      'prettier/prettier': 'error',
-      'arrow-body-style': 'off',
-      'prefer-arrow-callback': 'off',
-    },
-  },
+  // Disable ESLint rules that conflict with Prettier (must be last)
+  eslintConfigPrettier,
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,9 @@
         "babel-jest": "^30.4.1",
         "danger": "^13.0.10",
         "eslint": "^10.6.0",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import-x": "^4.17.1",
         "eslint-plugin-jest": "^29.15.4",
-        "eslint-plugin-prettier": "^5.5.6",
         "globals": "^17.7.0",
         "husky": "^9.1.7",
         "inquirer": "^14.0.2",
@@ -3421,9 +3421,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
-      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5342,6 +5342,22 @@
         }
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-import-context": {
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
@@ -5443,37 +5459,6 @@
           "optional": true
         },
         "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-prettier": {
-      "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.6.tgz",
-      "integrity": "sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.1",
-        "synckit": "^0.11.13"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-plugin-prettier"
-      },
-      "peerDependencies": {
-        "@types/eslint": ">=8.0.0",
-        "eslint": ">=8.0.0",
-        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
-        "prettier": ">=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/eslint": {
-          "optional": true
-        },
-        "eslint-config-prettier": {
           "optional": true
         }
       }
@@ -5776,13 +5761,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-diff": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/fast-json-patch": {
       "version": "3.1.1",
@@ -8965,19 +8943,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prettier-linter-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
-      "integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-diff": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   "scripts": {
     "build": "babel src --out-dir dist --ignore **/__tests__/,**/__fixtures__/,**/__mocks__/",
     "danger": "danger ci --failOnErrors",
+    "format:check": "prettier --check .",
+    "format:fix": "prettier --write .",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "lint:fix:staged": "eslint --fix",
@@ -41,7 +43,10 @@
   },
   "lint-staged": {
     "**/!(package-lock).json": "prettier --write",
-    "**/*.js": "npm run lint:fix:staged --",
+    "**/*.js": [
+      "prettier --write",
+      "npm run lint:fix:staged --"
+    ],
     "**/*.md": "prettier --write",
     "**/*.yml": "prettier --write"
   },
@@ -75,7 +80,7 @@
     "eslint": "^10.6.0",
     "eslint-plugin-import-x": "^4.17.1",
     "eslint-plugin-jest": "^29.15.4",
-    "eslint-plugin-prettier": "^5.5.6",
+    "eslint-config-prettier": "^10.1.8",
     "globals": "^17.7.0",
     "husky": "^9.1.7",
     "inquirer": "^14.0.2",


### PR DESCRIPTION
Follow [Prettier recommendation](https://prettier.io/docs/integrating-with-linters.html) about running Prettier independently instead of as an eslint pluggin.